### PR TITLE
Drop `has` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ function versionIncluded(nodeVersion, specifierValue) {
 
 var data = require('./core.json');
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 module.exports = function isCore(x, nodeVersion) {
-	return Object.prototype.hasOwnProperty.call(data, x) && versionIncluded(nodeVersion, data[x]);
+	return hasOwnProperty.call(data, x) && versionIncluded(nodeVersion, data[x]);
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var has = require('has');
-
 function specifierIncluded(current, specifier) {
 	var nodeParts = current.split('.');
 	var parts = specifier.split(' ');
@@ -65,5 +63,5 @@ function versionIncluded(nodeVersion, specifierValue) {
 var data = require('./core.json');
 
 module.exports = function isCore(x, nodeVersion) {
-	return has(data, x) && versionIncluded(nodeVersion, data[x]);
+	return Object.prototype.hasOwnProperty.call(data, x) && versionIncluded(nodeVersion, data[x]);
 };

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
 		"url": "https://github.com/inspect-js/is-core-module/issues"
 	},
 	"homepage": "https://github.com/inspect-js/is-core-module",
-	"dependencies": {
-		"has": "^1.0.3"
-	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^17.5.0",
 		"aud": "^1.1.3",


### PR DESCRIPTION
I noticed that `has` is only used once and the package itself depends on a 50-line sub-dependency. I think it could be dropped and replaced with about 20 characters so that `is-core-module` users won’t have to download and install 2 additional packages. 