### PR TITLE
[Deps] remove the prod dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var has = require('has');
-
 function specifierIncluded(current, specifier) {
 	var nodeParts = current.split('.');
 	var parts = specifier.split(' ');
@@ -63,7 +61,8 @@ function versionIncluded(nodeVersion, specifierValue) {
 }
 
 var data = require('./core.json');
+var has = Object.prototype.hasOwnProperty;
 
 module.exports = function isCore(x, nodeVersion) {
-	return has(data, x) && versionIncluded(nodeVersion, data[x]);
+	return has.call(data, x) && versionIncluded(nodeVersion, data[x]);
 };

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
 		"url": "https://github.com/inspect-js/is-core-module/issues"
 	},
 	"homepage": "https://github.com/inspect-js/is-core-module",
-	"dependencies": {
-		"has": "^1.0.3"
-	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^17.6.0",
 		"aud": "^1.1.5",


### PR DESCRIPTION
Hi!

[Close to 20% of the bundle size is due to the dependency 'has'](https://bundlephobia.com/result?p=is-core-module@2.4.0). By removing that, the package is lighter and save bits for the planet :)